### PR TITLE
fix: set fixed version of std lib to 0.97.0 (#41)

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,23 +1,23 @@
-export { parse } from 'https://deno.land/std@0.81.0/flags/mod.ts'
-export { acceptWebSocket } from 'https://deno.land/std@0.81.0/ws/mod.ts'
+export { parse } from 'https://deno.land/std@0.97.0/flags/mod.ts'
+export { acceptWebSocket } from 'https://deno.land/std@0.97.0/ws/mod.ts'
 export {
   serve,
   Server,
   serveTLS,
   ServerRequest,
-} from 'https://deno.land/std@0.81.0/http/server.ts'
+} from 'https://deno.land/std@0.97.0/http/server.ts'
 export {
   blue,
   bold,
   green,
   red,
-} from 'https://deno.land/std@0.81.0/fmt/colors.ts'
-export { posix } from 'https://deno.land/std@0.81.0/path/mod.ts'
-export { extname } from 'https://deno.land/std@0.81.0/path/mod.ts'
+} from 'https://deno.land/std@0.97.0/fmt/colors.ts'
+export { posix } from 'https://deno.land/std@0.97.0/path/mod.ts'
+export { extname } from 'https://deno.land/std@0.97.0/path/mod.ts'
 export {
   assert,
   assertEquals,
-} from 'https://deno.land/std@0.81.0/testing/asserts.ts'
-export { TextProtoReader } from 'https://deno.land/std@0.81.0/textproto/mod.ts'
-export { BufReader } from 'https://deno.land/std@0.81.0/io/bufio.ts'
-export type { Args } from 'https://deno.land/std@0.81.0/flags/mod.ts'
+} from 'https://deno.land/std@0.97.0/testing/asserts.ts'
+export { TextProtoReader } from 'https://deno.land/std@0.97.0/textproto/mod.ts'
+export { BufReader } from 'https://deno.land/std@0.97.0/io/bufio.ts'
+export type { Args } from 'https://deno.land/std@0.97.0/flags/mod.ts'


### PR DESCRIPTION
Fix problem install in Deno 1.16 

```sh
error: TS2339 [ERROR]: Property 'getIterator' does not exist on type 'ReadableStream<R>'.
  return res.readable.getIterator();
                      ~~~~~~~~~~~
    at https://deno.land/std@0.81.0/async/pool.ts:45:23
```